### PR TITLE
Preload the Amp runtime v0.js

### DIFF
--- a/lib/HtmlComponentBuilder.js
+++ b/lib/HtmlComponentBuilder.js
@@ -15,6 +15,7 @@ class HtmlComponentBuilder {
               <meta charSet="utf-8" />
               <meta name="amp-google-client-id-api" content="googleanalytics" />
               <meta name="viewport" content="width=device-width,minimum-scale=1,initial-scale=1" />
+              <link rel="preload" as="script" href="${constants.AMP_CDN_HOST}/v0.js"/>
               <title>{title}</title>
               <link rel="canonical" href={canonical} />
               {headComponents}


### PR DESCRIPTION
因為在完成下載 ` https://cdn.ampproject.org/v0.js ` 之前，AMP boilerplate會把body設成 ` visibility:hidden `，或許preload起來會對performance有一點幫助，避免` visibility:hidden `的時間過長。

參考來源：https://amp.dev/documentation/guides-and-tutorials/optimize-and-measure/optimize_amp.html?format=websites#optimize-the-amp-runtime-loading